### PR TITLE
Changed column resizer ui

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -11,7 +11,7 @@
               ></component>
             </template>
           </slot>
-          <tr v-if="columnResize">
+          <!-- <tr v-if="columnResize">
             <td v-for="(field, index) in visibleFields" class="resize-slider">
               <input type="range" min="1" max="100" value="100" style="width: 100%;"
                      class="resize-slider"
@@ -22,7 +22,7 @@
                      v-if="index === (visibleFields.length - 1)"
                      @click.prevent="noop" @mousedown.prevent="noop">
             </td>
-          </tr>
+          </tr> -->
         </thead>
       </table>
     </div>
@@ -498,7 +498,9 @@ export default {
 },
 
   methods: {
+
     resizeCol (event, index) {
+      console.log("resize col called");
       event.preventDefault();
       const rightHead = index < this.countVisibleFields - 1
         ? this.visibleFields[index + 1] : null;
@@ -521,6 +523,7 @@ export default {
         }
       };
       const onMouseUp = () => {
+        console.log("mouse up called");
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', onMouseUp);
         const rightHeadWidth = rightHead ? rightHead.width : null;
@@ -1237,6 +1240,30 @@ export default {
   [v-cloak] {
     display: none;
   }
+  [class*='vuetable-th-'] {
+    border-style: solid !important;
+    padding: 0px !important;
+    position: relative;
+    line-height: 50px;
+  }
+  [class*='vuetable-th-']::before {
+    content: "";
+    min-width: 10px;
+    display: inline-block;
+    height: 100%;
+    cursor: col-resize;
+    float: left;
+  }
+
+  [class*='vuetable-th-']::after {
+    content: "";
+    min-width: 10px;
+    display: inline-block;
+    height: 100%;
+    cursor: col-resize;
+    float: right;
+  }
+
   table.vuetable.fixed-header {
     table-layout: fixed;
   }

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -370,7 +370,8 @@ export default {
       lastScrollPosition: 0,
       scrollBarWidth: '17px', //chrome default
       scrollVisible: false,
-      $_css: {}
+      $_css: {},
+      isDragged: false
     }
   },
 
@@ -500,8 +501,8 @@ export default {
   methods: {
 
     resizeCol (event, index) {
-      console.log("resize col called");
       event.preventDefault();
+      this.isDragged = true;
       const rightHead = index < this.countVisibleFields - 1
         ? this.visibleFields[index + 1] : null;
       const currHead = this.visibleFields[index];
@@ -523,7 +524,6 @@ export default {
         }
       };
       const onMouseUp = () => {
-        console.log("mouse up called");
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', onMouseUp);
         const rightHeadWidth = rightHead ? rightHead.width : null;
@@ -1246,21 +1246,19 @@ export default {
     position: relative;
     line-height: 50px;
   }
-  [class*='vuetable-th-']::before {
+  [class*='vuetable-th-']::before, [class*='vuetable-th-']::after {
     content: "";
     min-width: 10px;
     display: inline-block;
     height: 100%;
     cursor: col-resize;
+  }
+
+  [class*='vuetable-th-']::before { 
     float: left;
   }
 
   [class*='vuetable-th-']::after {
-    content: "";
-    min-width: 10px;
-    display: inline-block;
-    height: 100%;
-    cursor: col-resize;
     float: right;
   }
 

--- a/src/components/VuetableRowHeader.vue
+++ b/src/components/VuetableRowHeader.vue
@@ -54,12 +54,6 @@ export default {
     VuetableColGutter
   },
 
-  data(){
-    return {
-      isMouseDown: false
-    }
-  },
-
   computed: {
     sortOrder() {
       return this.$parent.sortOrder

--- a/src/components/VuetableRowHeader.vue
+++ b/src/components/VuetableRowHeader.vue
@@ -12,7 +12,7 @@
             :class="headerClass('vuetable-th-component', field)"
             :style="{width: field.width}"
             @vuetable:header-event="vuetable.onHeaderEvent"
-            @click="onColumnHeaderClicked(field, $event)"
+            @mousedown="onColumnHeaderClicked(field, $event)"
           ></component>
         </template>
         <template v-else-if="vuetable.isFieldSlot(field.name)">
@@ -20,16 +20,16 @@
               :key="fieldIndex"
               :style="{width: field.width}"
               v-html="renderTitle(field)"
-              @click="onColumnHeaderClicked(field, $event)"
+              @mousedown="onColumnHeaderClicked(field, $event)"
           ></th>
         </template>
         <template v-else>
-          <th @click="onColumnHeaderClicked(field, $event)"
-            :key="fieldIndex"
-            :id="'_' + field.name"
-            :class="headerClass('vuetable-th', field)"
-            :style="{width: field.width}"
-            v-html="renderTitle(field)"
+          <th @mousedown="onColumnHeaderClicked(field, $event)"
+              :key="fieldIndex"
+              :id="'_' + field.name"
+              :class="headerClass('vuetable-th', field)"
+              :style="{width: field.width}"
+              v-html="renderTitle(field)"
           ></th>
         </template>
       </template>
@@ -137,7 +137,7 @@ export default {
       let title = this.getTitle(field)
 
       if (title.length > 0 && this.isInCurrentSortGroup(field) || this.hasSortableIcon(field)) {
-        let style = `opacity:${this.sortIconOpacity(field)};position:relative;float:right`
+        let style = `opacity:${this.sortIconOpacity(field)};position:absolute;right: 15px; top: 18px;`
         let iconTag = this.vuetable.showSortIcons ? this.renderIconTag(['sort-icon', this.sortIcon(field)], `style="${style}"`) : ''
         return title + ' ' + iconTag
       }
@@ -187,8 +187,18 @@ export default {
     },
 
     onColumnHeaderClicked (field, event) {
-      this.vuetable.orderBy(field, event)
-    }
+      const visibleFields = this.vuetable.tableFields.filter(field => field.visible);
+      console.log(visibleFields);
+      const index = visibleFields.findIndex(visibleField => visibleField.id === field.id);
+      if(event.offsetX <= 10 ) {
+        this.vuetable.resizeCol (event, index - 1);
+      } else if (event.target.offsetWidth - event.offsetX <= 10) {
+        this.vuetable.resizeCol (event, index);
+      } else {
+        this.vuetable.orderBy(field, event)
+      }
+    },
+
   }
 }
 </script>

--- a/src/components/VuetableRowHeader.vue
+++ b/src/components/VuetableRowHeader.vue
@@ -12,7 +12,8 @@
             :class="headerClass('vuetable-th-component', field)"
             :style="{width: field.width}"
             @vuetable:header-event="vuetable.onHeaderEvent"
-            @mousedown="onColumnHeaderClicked(field, $event)"
+            @mousedown="mouseDownEvent(field, $event)"
+            @click="onColumnHeaderClicked(field, $event)"
           ></component>
         </template>
         <template v-else-if="vuetable.isFieldSlot(field.name)">
@@ -20,16 +21,18 @@
               :key="fieldIndex"
               :style="{width: field.width}"
               v-html="renderTitle(field)"
-              @mousedown="onColumnHeaderClicked(field, $event)"
+              @mousedown="mouseDownEvent(field, $event)"
+              @click="onColumnHeaderClicked(field, $event)"
           ></th>
         </template>
         <template v-else>
-          <th @mousedown="onColumnHeaderClicked(field, $event)"
-              :key="fieldIndex"
+          <th :key="fieldIndex"
               :id="'_' + field.name"
               :class="headerClass('vuetable-th', field)"
               :style="{width: field.width}"
               v-html="renderTitle(field)"
+              @mousedown="mouseDownEvent(field, $event)"
+              @click="onColumnHeaderClicked(field, $event)"
           ></th>
         </template>
       </template>
@@ -49,6 +52,12 @@ export default {
     'vuetable-field-handle'  : VuetableFieldHandle,
     'vuetable-field-sequence': VuetableFieldSequence,
     VuetableColGutter
+  },
+
+  data(){
+    return {
+      isMouseDown: false
+    }
   },
 
   computed: {
@@ -187,17 +196,28 @@ export default {
     },
 
     onColumnHeaderClicked (field, event) {
-      const visibleFields = this.vuetable.tableFields.filter(field => field.visible);
-      console.log(visibleFields);
-      const index = visibleFields.findIndex(visibleField => visibleField.id === field.id);
-      if(event.offsetX <= 10 ) {
-        this.vuetable.resizeCol (event, index - 1);
-      } else if (event.target.offsetWidth - event.offsetX <= 10) {
-        this.vuetable.resizeCol (event, index);
-      } else {
-        this.vuetable.orderBy(field, event)
+      if(this.vuetable.isDragged){
+        this.vuetable.isDragged = false;
+      }
+      else{
+        if(event.offsetX > 10 && event.target.offsetWidth - event.offsetX > 10){
+          this.vuetable.orderBy(field, event);
+        }
       }
     },
+
+    mouseDownEvent (field, event) {
+      if(event.offsetX <= 10 || event.target.offsetWidth - event.offsetX <= 10){
+        const visibleFields = this.vuetable.tableFields.filter(field => field.visible);
+        const index = visibleFields.findIndex(visibleField => visibleField.id === field.id);
+        if(event.offsetX <= 10 ) {
+          this.vuetable.resizeCol (event, index - 1);
+        } else {
+          this.vuetable.resizeCol (event, index);
+        }
+      }
+    }
+
 
   }
 }


### PR DESCRIPTION
Added separate event handlers for triggering column resizing and sorting functions.

UI changes:
- Removed the table header line which was previously used for resizing columns. (added screenshot for reference)
- Added border and pseudo-elements to the column headers. 
- CSS changes for proper positioning of icons and pseudo-elements. 


![new-col-resizer](https://user-images.githubusercontent.com/19431894/61711195-1662e380-ad71-11e9-87d3-e861a5d0d10e.png)
![old-col-resizer](https://user-images.githubusercontent.com/19431894/61711196-1662e380-ad71-11e9-9cae-803676157b67.png)

